### PR TITLE
fix zlib.compress() with the latest V compiler

### DIFF
--- a/pdf.v
+++ b/pdf.v
@@ -135,7 +135,7 @@ fn (o Obj) render_obj_cmpr(mut res_c strings.Builder, txt_parts string) !int {
 
 	// cmp_status := C.compress(buf.data, &cmp_len, charptr(txt.str), u32(txt.len))
 	txt_buf := '$o.txt$txt_parts'
-	buf := zlib.compress(txt_buf.bytes())!
+	buf := zlib.compress(txt_buf.bytes()) or { return error('compress failed') }
 
 	// mandatory fields in a compress obj stream
 	res_c.write('/Length1 $txt_buf.len'.bytes())!

--- a/ttf_font.v
+++ b/ttf_font.v
@@ -47,7 +47,7 @@ fn get_ttf_widths(mut tf ttf.TTF_File) []int {
 */
 
 fn render_ttf_files(mut res_c strings.Builder, tf TtfFontRsc) !int {
-	buf := zlib.compress(tf.tf.buf)!
+	buf := zlib.compress(tf.tf.buf) or { return error('compress failed') }
 	res_c.write("${tf.id_font_file} 0 obj\n".bytes())!
 	
 	// mandatory fields in a compress obj stream


### PR DESCRIPTION
This PR fix zlib.compress() with the latest V compiler.